### PR TITLE
Fix sequel deprecation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,6 @@ addons:
   postgresql: "9.4"
 env:
 rvm:
-  - 2.2.3
+  - 2.4.1
 notifications:
   email: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.2.3'
+ruby '2.4.1'
 
 # Specify your gem's dependencies in attr_pouch.gemspec
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,5 +31,8 @@ DEPENDENCIES
   rspec (~> 3.0)
   sequel (~> 4.13)
 
+RUBY VERSION
+   ruby 2.4.1p111
+
 BUNDLED WITH
-   1.10.6
+   1.14.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,7 +20,7 @@ GEM
     rspec-mocks (3.1.3)
       rspec-support (~> 3.1.0)
     rspec-support (3.1.2)
-    sequel (4.13.0)
+    sequel (4.49.0)
 
 PLATFORMS
   ruby
@@ -29,7 +29,7 @@ DEPENDENCIES
   attr_pouch!
   pg (~> 0.18.3)
   rspec (~> 3.0)
-  sequel (~> 4.13)
+  sequel (~> 4.46)
 
 RUBY VERSION
    ruby 2.4.1p111

--- a/attr_pouch.gemspec
+++ b/attr_pouch.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "rspec", '~> 3.0'
   gem.add_development_dependency "pg", '~> 0.18.3'
-  gem.add_development_dependency "sequel", '~> 4.13'
+  gem.add_development_dependency "sequel", '~> 4.46'
 end


### PR DESCRIPTION
I'm attempting to fix a Sequel deprecation that appeared in Sequel 4.46.0, the removal of `def_dataset_method`: https://github.com/jeremyevans/sequel/commit/a5a4d8020438b594ec9c1f61211ee292468998ba#diff-19563bb8ba8978dd57bcf392dc256d1bR134

Also took the chance to update the Ruby version.