### PR TITLE
Fix default object reuse

### DIFF
--- a/lib/attr_pouch.rb
+++ b/lib/attr_pouch.rb
@@ -332,7 +332,7 @@ module AttrPouch
         define_method("#{name.to_s.sub(/\?\z/, '')}=") do |value|
           store = self[storage_field]
           was_nil = store.nil?
-          store = default if was_nil
+          store = default.dup if was_nil
           changed = field.write(store, value)
           if was_nil
             self[storage_field] = store
@@ -368,7 +368,7 @@ module AttrPouch
           define_method("#{raw_name.to_s.sub(/\?\z/, '')}=") do |value|
             store = self[storage_field]
             was_nil = store.nil?
-            store = default if was_nil
+            store = default.dup if was_nil
             changed = field.write(store, value, encode: false)
             if was_nil
               self[storage_field] = store

--- a/spec/attr_pouch_spec.rb
+++ b/spec/attr_pouch_spec.rb
@@ -57,6 +57,14 @@ describe AttrPouch do
           expect(pouchy.foo).to eq('bar')
         end
 
+        it "has different object IDs for different object pouches" do
+          pouchy1 = pouchy.class.new(foo: "bar")
+          pouchy2 = pouchy.class.new(foo: "baz")
+          pouch1_id = pouchy1.send(column_name).object_id
+          pouch2_id = pouchy2.send(column_name).object_id
+          expect(pouch1_id).not_to eq(pouch2_id)
+        end
+
         it "avoids marking the field as modified if it is not changing" do
           pouchy.foo = 'bar'
           expect(pouchy.save_changes).to_not be_nil


### PR DESCRIPTION
As I slacked you about, the default pouch object was getting reused between instances:

```
[26] pry(#<MyCommand>)> MyClass.new(name: "foo").metadata.object_id
=> 70291928501780
[27] pry(#<MyCommand>)> MyClass.new(name: "foo").metadata.object_id
=> 70291928501780
[28] pry(#<MyCommand>)> MyClass.new(name: "foo").metadata.object_id
=> 70291928501780
[29] pry(#<MyCommand>)> MyClass.new(name: "foo").metadata.object_id
=> 70291928501780
```

This adds a failing test case, and fixes it.